### PR TITLE
Adding sides of the DEM

### DIFF
--- a/template.html
+++ b/template.html
@@ -203,15 +203,15 @@ ${scripts}
                                                         side: THREE.DoubleSide});
 
     // Sides
-    var side_width;
+    var side_width, side_depth = 3;
     for (var side in altitudes) {
       if (side == 'back' || side == 'front')
         side_width = plane_width;
       else
         side_width = plane_height;
 
-      var geom = new THREE.PlaneGeometry(side_width, 3,
-                                         altitudes[side].length, 1);
+      var geom = new THREE.PlaneGeometry(side_width, side_depth,
+                                         altitudes[side].length -1, 1);
 
       // Filling of the geometry vertices
       for (var i = 0, l = altitudes[side].length; i < l; i++) {
@@ -248,6 +248,7 @@ ${scripts}
     // Bottom
     var geom_bottom = new THREE.PlaneGeometry(plane_width, plane_height, 1, 1);
     var plane_bottom = new THREE.Mesh(geom_bottom, side_material);
+    plane_bottom.position.z = -side_depth/2;
     scene.add(plane_bottom);
 
     // Additional lights


### PR DESCRIPTION
![slection_009](https://f.cloud.github.com/assets/6261413/2193856/84b831f4-9883-11e3-9750-3a5709d5a487.jpeg)
Hello !
Great plugin !  It helped me for my internship to visualize easily my DEM in 3D.
I just was curious to see this visualisation with an "extruding" aspect so I created a function build_sides() to make this and the result is pretty cool. Let you see the picture above to make you an idea.

Hope you like it, and tell me if you want me to change something. 
