### PR TITLE
Other exporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## CHANGELOG
 
+### Version 1.1
+* updated the STLExporter to support other file formats (collada, obj) and is easier to extend (by Olivier Dalang)
+
 ### Version 1.0
 * layer opacity sliders in dat-gui panel
 * wireframe mode

--- a/docs/ExportSettings.html
+++ b/docs/ExportSettings.html
@@ -68,9 +68,9 @@
 <p>This template has a <a href="https://code.google.com/p/dat-gui/">dat-gui</a> panel, which makes it possible to toggle layer visibility, adjust layer opacity and add a horizontal plane movable in the vertical direction.</p></li>
 <li><p>STLExport.html</p>
 
-<p>This template builds 3D models on the web browser, but doesn't render them. Instead, it has some buttons to save 3D models in <a href="http://en.wikipedia.org/wiki/STL_%28file_format%29">STL format</a>. It also has ability to save the texture image(s).</p>
+<p>This template builds 3D models on the web browser, but doesn't render them. Instead, it has some buttons to save 3D models in <a href="http://en.wikipedia.org/wiki/STL_%28file_format%29">STL format</a>, <a href="http://en.wikipedia.org/wiki/Wavefront_.obj_file">Wavrefront OBJ format</a> or <a href="http://en.wikipedia.org/wiki/COLLADA">COLLADA format</a>. It also has ability to save the texture image(s).</p>
 
-<p>The STL format is widely supported by 3DCG softwares such as <a href="http://www.blender.org/">Blender</a>.</p></li>
+<p>Those formats are widely supported by 3DCG softwares such as <a href="http://www.blender.org/">Blender</a>.</p></li>
 </ul>
 
 <h3><a name="World"/> World</h3>

--- a/html_templates/FileExport.html
+++ b/html_templates/FileExport.html
@@ -16,12 +16,14 @@ body { margin: 5%; }
 #about ul { margin: 5px; margin-left: 20px; padding: 0px; }
 </style>
 </head>
-<body onLoad="listLayers()">
+<body onLoad="listLayers(); listExportAll();">
 <div id="webgl" style="display: none;"></div>
 
 <script src="./threejs/three.min.js"></script>
 <script src="./exporters/STLBinaryExporter.js"></script>
 <script src="./exporters/STLExporter.js"></script>
+<script src="./FileExporters/DAEExporter.js"></script>
+<script src="./FileExporters/OBJExporter.js"></script>
 <script src="./jszip/jszip.min.js"></script>
 <script src="./FileSaverjs/FileSaver.min.js"></script>
 <script src="./Qgis2threejs.js"></script>
@@ -46,17 +48,36 @@ project.layers.forEach(function (layer) {
 });
 
 // create an exporter
-var binaryExporter = new THREE.STLBinaryExporter(),
-    asciiExporter = new THREE.STLExporter();
+var parsers = {
+  'stl_binary': {
+    f: new THREE.STLBinaryExporter().parse,
+    ext: '.stl',
+    name: 'STL (binary)',
+    desc: 'This will only export the geometries.'},
+  'stl_ascii': {
+    f: new THREE.STLExporter().parse,
+    ext: '.stl',
+    name: 'STL (ascii)',
+    desc: 'This will only export the geometries.'},
+  'dae': {
+    f: new THREE.DAEExporter().parse,
+    ext: '.dae',
+    name: 'COLLADA (.dae)',
+    desc: 'This will export the geometries and the diffuse color.'},
+  'obj': {
+    f: new THREE.OBJExporter().parse,
+    ext: '.obj',
+    name: 'Wavefront (.obj)',
+    desc: 'This will export the geometries with reference to a material, but you\'ll have to redefine the material.'}
+};
 
-function exportLayersSTLZip(isBinary) {
 
-  var zip = new JSZip(), toSTL;
-  if (isBinary) toSTL = function (object) { return binaryExporter.parse(object).buffer; };
-  else toSTL = function (object) { return asciiExporter.parse(object); };
+function exportLayersZip(mode) {
 
-  function zipDEMBlock(filetitle, layer, block) {
-    zip.file(filetitle + ".stl", toSTL(block.obj));
+  var zip = new JSZip();
+
+  function zipDEMBlock(filetitle, layer, block) {    
+    zip.file(filetitle + parsers[mode].ext, parsers[mode].f(block.obj));
 
     var m = layer.materials[block.m];
     if (m.i === undefined) return;
@@ -67,10 +88,13 @@ function exportLayersSTLZip(isBinary) {
   }
 
   project.layers.forEach(function (layer, layer_index) {
+
+    var filetitle = layer_index + "_" + layer.name;
+
     if (layer.type == Q3D.LayerType.DEM) {
       // export blocks
       layer.blocks.forEach(function (block, index) {
-        var filetitle = layer_index + "_" + layer.name + "_" + index;
+        filetitle = filetitle + "_" + index;
         zipDEMBlock(filetitle, layer, block);
       });
 
@@ -81,22 +105,22 @@ function exportLayersSTLZip(isBinary) {
         for (var i = 0, l = aObjs.length; i < l; i++) {
           group.add(aObjs[i]);
         }
-        var filename = layer_index + "_" + layer.name + "_sides.stl";
-        zip.file(filename, toSTL(group));
+
+        filetitle = filetitle + "_sides" ;
+        zip.file(filetitle + parsers[mode].ext, parsers[mode].f(group));
       }
     } else {
-      var filename = layer_index + "_" + layer.name + ".stl";
-      zip.file(filename, toSTL(layer.objectGroup));
+      zip.file(filetitle + parsers[mode].ext, parsers[mode].f(layer.objectGroup));
     }
   });
   var content = zip.generate({type: "blob"});
   saveAs(content, project.title + ".zip");
 }
 
-function exportLayerToBinarySTL(index) {
+function exportLayer(index, mode) {
   var layer = project.layers[index];
-  var stlData = binaryExporter.parse(layer.objectGroup).buffer;
-  saveAs(new Blob([stlData]), layer.name + ".stl");
+  var filetitle = layer.name;
+  saveAs(new Blob([parsers[mode].f(layer.objectGroup)]), filetitle + parsers[mode].ext);  
 }
 
 function listLayers() {
@@ -105,13 +129,15 @@ function listLayers() {
     var e = document.createElement("li");
     e.appendChild(document.createTextNode(layer.name + " "));
 
-    // STL download button
-    var btn = document.createElement("a");
-    btn.href = "#";
-    btn.className = "btn";
-    btn.appendChild(document.createTextNode("STL"));
-    btn.onclick = function () { exportLayerToBinarySTL(index); return false; };
-    e.appendChild(btn);
+    Object.keys(parsers).forEach(function(k, i) {
+      var btn = document.createElement("a");
+      btn.href = "#";
+      btn.className = "btn";
+      btn.title = parsers[k].desc;
+      btn.appendChild(document.createTextNode(parsers[k].name));
+      btn.onclick = function () { exportLayer(index, k); return false; };
+      e.appendChild(btn);   
+    });
 
     // images
     if (layer.type == Q3D.LayerType.DEM) {
@@ -126,15 +152,29 @@ function listLayers() {
     ol.appendChild(e);
   });
 }
+
+function listExportAll(){
+
+  var div = document.getElementById("exportAll");
+
+  Object.keys(parsers).forEach(function(k, i) {
+      var btn = document.createElement("a");
+      btn.href = "#";
+      btn.className = "btn";
+      btn.title = parsers[k].desc;
+      btn.appendChild(document.createTextNode(parsers[k].name));
+      btn.onclick = function () { exportLayersZip(k); return false; };
+      div.appendChild(btn);   
+    });
+
+}
 </script>
 
 <div>You can save 3D models exported from <a href="https://github.com/minorua/Qgis2threejs" target="_blank">Qgis2threejs</a></div>
 <hr>
 <br>
 <h4>Save all layers:</h4>
-<div>
-<a class="btn" style="font-size:x-large;" href="#" onclick="exportLayersSTLZip(true);return false;">Zip all layers</a>
-<a class="btn" style="font-size:small;" href="#" onclick="exportLayersSTLZip(false);return false;">ASCII</a>
+<div id="exportAll">
 </div>
 <br><br><br>
 
@@ -146,8 +186,8 @@ function listLayers() {
 
 <div id="about">
 <h4>About output of DEM layer with sides and bottom</h4>
-When you press the Zip all layers button, DEM and sides + bottom are output to separate files in zip archive --> for 3DCG software.<br>
-When you press the STL button of the DEM layer, DEM and sides + bottom are joined and output to a single file --> for 3D printing.
+When you export all layers at once, DEM and sides/bottom are output to separate files in the zip archive --> for 3DCG software.<br>
+When you export the DEM layer only, DEM and sides/bottom are joined and output to a single file --> for 3D printing.
 
 <h4>About this page</h4>
 <div>This page uses the following libraries:</div>

--- a/html_templates/FileExport.html
+++ b/html_templates/FileExport.html
@@ -24,6 +24,7 @@ body { margin: 5%; }
 <script src="./exporters/STLExporter.js"></script>
 <script src="./FileExporters/DAEExporter.js"></script>
 <script src="./FileExporters/OBJExporter.js"></script>
+<script src="./FileExporters/OBJMaterialExporter.js"></script>
 <script src="./jszip/jszip.min.js"></script>
 <script src="./FileSaverjs/FileSaver.min.js"></script>
 <script src="./Qgis2threejs.js"></script>
@@ -68,7 +69,12 @@ var parsers = {
     f: new THREE.OBJExporter().parse,
     ext: '.obj',
     name: 'Wavefront (.obj)',
-    desc: 'This will export the geometries with reference to a material, but you\'ll have to redefine the material.'}
+    desc: 'This will export the geometries with reference to a material, but you\'ll have to redefine the material.'},
+  'objmtl': {
+    f: new THREE.OBJMaterialExporter().parse,
+    ext: '.mtl',
+    name: 'Wavefront material library (.mtl)',
+    desc: 'This will export the material library to be used with the .obj export. You must place this file alongside the .obj files for it to work.'}
 };
 
 
@@ -77,7 +83,7 @@ function exportLayersZip(mode) {
   var zip = new JSZip();
 
   function zipDEMBlock(filetitle, layer, block) {    
-    zip.file(filetitle + parsers[mode].ext, parsers[mode].f(block.obj));
+    zip.file(filetitle + parsers[mode].ext, parsers[mode].f(block.obj, filetitle));
 
     var m = layer.materials[block.m];
     if (m.i === undefined) return;
@@ -107,10 +113,10 @@ function exportLayersZip(mode) {
         }
 
         filetitle = filetitle + "_sides" ;
-        zip.file(filetitle + parsers[mode].ext, parsers[mode].f(group));
+        zip.file(filetitle + parsers[mode].ext, parsers[mode].f(group, filetitle));
       }
     } else {
-      zip.file(filetitle + parsers[mode].ext, parsers[mode].f(layer.objectGroup));
+      zip.file(filetitle + parsers[mode].ext, parsers[mode].f(layer.objectGroup, filetitle));
     }
   });
   var content = zip.generate({type: "blob"});
@@ -120,7 +126,7 @@ function exportLayersZip(mode) {
 function exportLayer(index, mode) {
   var layer = project.layers[index];
   var filetitle = layer.name;
-  saveAs(new Blob([parsers[mode].f(layer.objectGroup)]), filetitle + parsers[mode].ext);  
+  saveAs(new Blob([parsers[mode].f(layer.objectGroup, filetitle)]), filetitle + parsers[mode].ext);  
 }
 
 function listLayers() {

--- a/html_templates/FileExport.txt
+++ b/html_templates/FileExport.txt
@@ -1,0 +1,5 @@
+[general]
+filename=FileExport.html
+description=This template has ability to save exported models in various 3D formats
+files=js/Qgis2threejs.js
+dirs=js/threejs/exporters,js/FileExporters,js/FileSaverjs,js/jszip

--- a/html_templates/STLExport.txt
+++ b/html_templates/STLExport.txt
@@ -1,5 +1,0 @@
-[general]
-filename=STLExport.html
-description=This template has ability to save exported models in STL format
-files=js/Qgis2threejs.js
-dirs=js/threejs/exporters,js/FileSaverjs,js/jszip

--- a/js/FileExporters/DAEExporter.js
+++ b/js/FileExporters/DAEExporter.js
@@ -1,0 +1,275 @@
+/**
+ * @author olivier dalang / https://github.com/olivierdalang
+ * based on STLExport.js by mrdoob / http://mrdoob.com/
+ */
+
+ 
+THREE.DAEExporter = function () {};
+
+THREE.DAEExporter.prototype = {
+
+	constructor: THREE.DAEExporter,
+
+	parse: ( function ( scene ) {
+
+			var vector = new THREE.Vector3();
+			var normalMatrixWorld = new THREE.Matrix3();
+
+
+			/*************************************/
+			/* HEADER                            */
+			/*************************************/
+
+			var output = '<?xml version="1.0" encoding="utf-8"?>'+ '\n';
+			output +=  	 '<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">'+ '\n';
+			output +=  	 ' <asset>'+ '\n';
+			//output +=  	 ' 	<created>2005-11-14T02:16:38Z</created>'+ '\n';
+			//output +=  	 ' 	<modified>2005-11-15T11:36:38Z</modified>'+ '\n';
+			//output +=  	 ' 	<revision>1.0</revision>'+ '\n';
+			output +=  	 ' </asset>'+ '\n';
+
+
+
+			/*************************************/
+			/* MATERIALS                         */
+			/*************************************/
+
+
+			var obj_i = 0;
+
+			var materials_hexstrings = [];
+			output +=  	 '<library_effects>'+ '\n';
+
+			scene.traverse( function ( object ) {
+
+				if ( object instanceof THREE.Mesh ) {
+
+					var geometry = object.geometry;
+					var matrixWorld = object.matrixWorld;
+
+					if ( geometry instanceof THREE.Geometry ) {
+
+						obj_i += 1;
+
+						var material = object.material;
+						var hexString = material.color.getHexString();
+
+						if( materials_hexstrings.indexOf(hexString)==-1 ){
+
+							materials_hexstrings.push(hexString);
+
+							output += '	<effect id="effect_'+hexString+'">' + '\n';
+							output += '		<profile_COMMON>' + '\n';
+							output += '			<technique sid="phong1">' + '\n';
+							output += '				<phong>' + '\n';
+							//output += '					<emission>' + '\n';
+							//output += '						<color>1.0 1.0 1.0 1.0</color>' + '\n';
+							//output += '					</emission>' + '\n';
+							//output += '					<ambient>' + '\n';
+							//output += '						<color>1.0 1.0 1.0 1.0</color>' + '\n';
+							//output += '					</ambient>' + '\n';
+							output += '					<diffuse>' + '\n';
+							output += '						<color>'+(material.color.r)+' '+(material.color.g)+' '+(material.color.b)+' 1.0</color>' + '\n';
+							output += '					</diffuse>' + '\n';
+							//output += '					<specular>' + '\n';
+							//output += '						<color>1.0 1.0 1.0 1.0</color>' + '\n';
+							//output += '					</specular>' + '\n';
+							//output += '					<shininess>' + '\n';
+							//output += '						<float>20.0</float>' + '\n';
+							//output += '					</shininess>' + '\n';
+							//output += '					<reflective>' + '\n';
+							//output += '						<color>1.0 1.0 1.0 1.0</color>' + '\n';
+							//output += '					</reflective>' + '\n';
+							//output += '					<reflectivity>' + '\n';
+							//output += '						<float>0.5</float>' + '\n';
+							//output += '					</reflectivity>' + '\n';
+							//output += '					<transparent>' + '\n';
+							//output += '						<color>1.0 1.0 1.0 1.0</color>' + '\n';
+							//output += '					</transparent>' + '\n';
+							output += '					<transparency>' + '\n';
+							output += '						<float>'+(material.opacity)+'</float>' + '\n';
+							output += '					</transparency>' + '\n';
+							output += '				</phong>' + '\n';
+							output += '			</technique>' + '\n';
+							output += '		</profile_COMMON>' + '\n';
+							output += '	</effect>' + '\n';
+
+						}
+
+					}
+				}
+			} );
+
+			output +=  	 '</library_effects>'+ '\n';
+
+
+
+			var obj_i = 0;
+
+			output +=  	 '<library_materials>'+ '\n';
+
+			for (var i = 0; i < materials_hexstrings.length; i++) {
+				var hexString = materials_hexstrings[i]
+				output += '		<material id="material_'+hexString+'">' + '\n';
+				output += '			<instance_effect url="#effect_'+(hexString)+'"/>' + '\n';
+				output += '		</material> ' + '\n';
+			};
+
+			output +=  	 '</library_materials>'+ '\n';
+
+
+
+			/*************************************/
+			/* GEOMETRIES                        */
+			/*************************************/
+
+
+			var obj_i = 0;
+			output +=  	 '<library_geometries>'+ '\n';
+
+			scene.traverse( function ( object ) {
+
+				if ( object instanceof THREE.Mesh ) {
+
+					var geometry = object.geometry;
+					var matrixWorld = object.matrixWorld;
+
+					if ( geometry instanceof THREE.Geometry ) {
+
+						obj_i += 1;
+
+						var vertices = geometry.vertices;
+						var faces = geometry.faces;
+
+						output += '	<geometry id="geometry_'+(obj_i)+'" name="object">' + '\n';
+						output += '		<mesh>' + '\n';
+
+						output += '			<source id="position_'+(obj_i)+'">' + '\n';
+						output += '				<float_array id="position_array_'+(obj_i)+'" count="'+(vertices.length*3)+'">' + '\n';
+						
+						for ( var i = 0, l = vertices.length; i < l; i ++ ) {
+							var vertex = vertices[ i ];
+							vector.copy( vertex ).applyMatrix4( matrixWorld );
+							output += '			' + vector.x + ' ' + vector.z + ' ' + vector.y + '\n';
+						}
+						output += '				</float_array>' + '\n';
+						output += '				<technique_common>' + '\n';
+						output += '					<accessor source="#position_array_'+(obj_i)+'" count="'+(faces.length*3)+'" stride="3">' + '\n';
+						output += '						<param name="X" type="float" />' + '\n';
+						output += '						<param name="Y" type="float" />' + '\n';
+						output += '						<param name="Z" type="float" />' + '\n';
+						output += '					</accessor>' + '\n';
+						output += '				</technique_common>' + '\n';
+						output += '			</source>' + '\n';
+
+
+
+						output += '			<source id="normal_'+(obj_i)+'">' + '\n';
+						output += '				<float_array id="normal_array_'+(obj_i)+'" count="'+(faces.length*3)+'">' + '\n';
+						
+						normalMatrixWorld.getNormalMatrix( matrixWorld );
+						for ( var i = 0, l = faces.length; i < l; i ++ ) {
+							var face = faces[ i ];
+
+							vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
+							output += '			' + vector.x + ' ' + vector.z + ' ' + vector.y + '\n';
+						}
+						output += '				</float_array>' + '\n';
+						output += '				<technique_common>' + '\n';
+						output += '					<accessor source="#normal_array_'+(obj_i)+'" count="'+(faces.length)+'" stride="3">' + '\n';
+						output += '						<param name="X" type="float" />' + '\n';
+						output += '						<param name="Y" type="float" />' + '\n';
+						output += '						<param name="Z" type="float" />' + '\n';
+						output += '					</accessor>' + '\n';
+						output += '				</technique_common>' + '\n';
+						output += '			</source>' + '\n';
+
+						output += '			<vertices id="vertex_'+(obj_i)+'" count="'+(faces.length*3)+'">' + '\n';
+						output += '				<input semantic="POSITION" source="#position_'+(obj_i)+'" offset="0"/> ' + '\n';
+						output += '			</vertices>' + '\n';
+
+						output += '			<triangles count="'+(faces.length)+'" material="MATERIAL">' + '\n';
+						output += '				<input semantic="VERTEX" source="#vertex_'+(obj_i)+'" offset="0"/> ' + '\n';
+						output += '				<input semantic="NORMAL" source="#normal_'+(obj_i)+'" offset="1"/> ' + '\n';
+						output += '				<p> ' + '\n';
+
+						for ( var i = 0, l = faces.length; i < l; i ++ ) {
+							var face = faces[ i ];
+							var indices = [ face.a, face.b, face.c ];
+							output += '			' + face.c + ' ' + i + ' ' + face.b + ' ' + i + ' ' + face.a + ' ' + i + '\n';
+						}
+
+						output += '				</p> ' + '\n';
+						output += '			</triangles>' + '\n';
+
+						output += '		</mesh>' + '\n';
+						output += '	</geometry>' + '\n';
+
+					}
+
+				}
+
+			} );
+
+			output +=  	 '</library_geometries>'+ '\n';
+
+
+
+
+			/*************************************/
+			/* SCENE                             */
+			/*************************************/
+
+
+			var obj_i = 0;
+			output +=  	 '<library_visual_scenes>'+ '\n';
+			output +=  	 '	<visual_scene id="DefaultScene">'+ '\n';
+
+			scene.traverse( function ( object ) {
+
+				if ( object instanceof THREE.Mesh ) {
+
+					var geometry = object.geometry;
+
+					if ( geometry instanceof THREE.Geometry ) {
+
+						obj_i += 1;
+
+						var material = object.material;
+
+						output +=  	 '		<node id="obj_'+(obj_i)+'" name="Object">'+ '\n';
+						output +=  	 '			<translate> 0 0 0</translate>'+ '\n';
+						output +=  	 ' 			<rotate> 0 0 1 0</rotate>'+ '\n';
+						output +=  	 ' 			<rotate> 0 1 0 0</rotate>'+ '\n';
+						output +=  	 ' 			<rotate> 1 0 0 0</rotate>'+ '\n';
+						output +=  	 ' 			<scale> 1 1 1</scale>'+ '\n';
+
+						output +=  	 '			<instance_geometry url="#geometry_'+(obj_i)+'">'+ '\n';
+						output +=  	 '				<bind_material>'+ '\n';
+						output +=  	 '					<technique_common>'+ '\n';
+						output +=  	 '						<instance_material symbol="MATERIAL" target="#material_'+(material.color.getHexString())+'"/>'+ '\n';
+						output +=  	 '					</technique_common>'+ '\n';
+						output +=  	 '				</bind_material>'+ '\n';
+						output +=  	 '			</instance_geometry>'+ '\n';
+
+						output +=  	 ' 		</node>'+ '\n';
+
+					}
+				}
+
+			} );
+
+			output +=  	 ' </visual_scene>'+ '\n';
+			output +=  	 '</library_visual_scenes>'+ '\n';
+
+
+			output +=  	 '<scene>'+ '\n';
+			output +=  	 ' <instance_visual_scene url="#DefaultScene"/>'+ '\n';
+			output +=  	 '</scene>'+ '\n';
+			output +=  	 '</COLLADA>';				
+
+			return output;
+
+		} )
+
+};

--- a/js/FileExporters/LICENSE
+++ b/js/FileExporters/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) DAEExport.js authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/js/FileExporters/LICENSE
+++ b/js/FileExporters/LICENSE
@@ -1,6 +1,7 @@
 The MIT License
 
-Copyright (c) DAEExport.js authors
+Copyright (c) 2015 Olivier Dalang
+Copyright (c) 2010-2015 three.js authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/js/FileExporters/OBJExporter.js
+++ b/js/FileExporters/OBJExporter.js
@@ -1,0 +1,72 @@
+/**
+ * @author olivier dalang / https://github.com/olivierdalang
+ * based on STLExport.js by mrdoob / http://mrdoob.com/
+ */
+ 
+THREE.OBJExporter = function () {};
+
+THREE.OBJExporter.prototype = {
+
+	constructor: THREE.OBJExporter,
+
+	parse: ( function ( scene ) {
+
+			var vector = new THREE.Vector3();
+			var normalMatrixWorld = new THREE.Matrix3();
+
+			var output = '';
+			var v_index = 1;
+			var o_index = 1;
+
+			scene.traverse( function ( object ) {
+
+				if ( object instanceof THREE.Mesh ) {
+
+					var geometry = object.geometry;
+					var matrixWorld = object.matrixWorld;
+					
+					var material = object.material;
+					var hexString = material.color.getHexString();
+
+					if ( geometry instanceof THREE.Geometry ) {
+
+						output += 'usemtl Mat_' + (hexString) + '\n';
+						output += 'g Object_' + (o_index) + '\n';
+						o_index += 1;
+
+						var vertices = geometry.vertices;
+						var faces = geometry.faces;
+
+						normalMatrixWorld.getNormalMatrix( matrixWorld );
+
+						for ( var i = 0, l = faces.length; i < l; i ++ ) {
+
+							var face = faces[ i ];
+
+							vector.copy( face.normal ).applyMatrix3( normalMatrixWorld ).normalize();
+
+							var indices = [ face.a, face.b, face.c ];
+
+							for ( var j = 0; j < 3; j ++ ) {
+
+								vector.copy( vertices[ indices[ j ] ] ).applyMatrix4( matrixWorld );
+
+								output += 'v ' + vector.x + ' ' + vector.z + ' ' + vector.y + '\n';
+
+							}
+							output += 'f ' + (v_index+2) + ' ' + (v_index+1) + ' ' + (v_index) + '\n';
+							v_index += 3;
+
+						}
+
+					}
+
+				}
+
+			} );		
+
+			return output;
+
+		} )
+
+};

--- a/js/FileExporters/OBJExporter.js
+++ b/js/FileExporters/OBJExporter.js
@@ -9,7 +9,7 @@ THREE.OBJExporter.prototype = {
 
 	constructor: THREE.OBJExporter,
 
-	parse: ( function ( scene ) {
+	parse: ( function ( scene, filetitle ) {
 
 			var vector = new THREE.Vector3();
 			var normalMatrixWorld = new THREE.Matrix3();
@@ -17,6 +17,8 @@ THREE.OBJExporter.prototype = {
 			var output = '';
 			var v_index = 1;
 			var o_index = 1;
+
+			output += 'mtllib '+ filetitle + '.mtl' + '\n';
 
 			scene.traverse( function ( object ) {
 
@@ -51,7 +53,7 @@ THREE.OBJExporter.prototype = {
 
 								vector.copy( vertices[ indices[ j ] ] ).applyMatrix4( matrixWorld );
 
-								output += 'v ' + vector.x + ' ' + vector.z + ' ' + vector.y + '\n';
+								output += 'v ' + -vector.x + ' ' + vector.z + ' ' + vector.y + '\n';
 
 							}
 							output += 'f ' + (v_index+2) + ' ' + (v_index+1) + ' ' + (v_index) + '\n';

--- a/js/FileExporters/OBJMaterialExporter.js
+++ b/js/FileExporters/OBJMaterialExporter.js
@@ -1,0 +1,58 @@
+/**
+ * @author olivier dalang / https://github.com/olivierdalang
+ * based on STLExport.js by mrdoob / http://mrdoob.com/
+ */
+ 
+THREE.OBJMaterialExporter = function () {};
+
+THREE.OBJMaterialExporter.prototype = {
+
+	constructor: THREE.OBJMaterialExporter,
+
+	parse: ( function ( scene ) {
+
+			var vector = new THREE.Vector3();
+			var normalMatrixWorld = new THREE.Matrix3();
+
+			var output = '';
+			var v_index = 1;
+			var o_index = 1;
+
+			var materials_hexstrings = [];
+
+			scene.traverse( function ( object ) {
+
+				if ( object instanceof THREE.Mesh ) {
+
+					var geometry = object.geometry;
+					var matrixWorld = object.matrixWorld;
+					
+					var material = object.material;
+					var hexString = material.color.getHexString();
+
+					if ( geometry instanceof THREE.Geometry ) {
+
+						var material = object.material;
+						var hexString = material.color.getHexString();
+
+						if( materials_hexstrings.indexOf(hexString)==-1 ){
+
+							materials_hexstrings.push(hexString);
+							output += 'newmtl Mat_' + (hexString) + '\n';
+							output += 'Kd ' + (material.color.r)+' '+(material.color.g)+' '+(material.color.b) + '\n';
+							output += 'Tr ' + (material.opacity) + '\n';//# some implementations use tr for transparency
+							output += 'd ' + (material.opacity) + '\n';//# some implementations use d for transparency
+
+						}
+
+					}
+
+				}
+
+			} );
+
+			return output;
+
+		} )
+
+};

--- a/js/threejs/exporters/STLBinaryExporter.js
+++ b/js/threejs/exporters/STLBinaryExporter.js
@@ -70,7 +70,8 @@ THREE.STLBinaryExporter.prototype = {
 
 			} );
 			
-			return output;
+			//return output;
+			return output.buffer; // Qgis2threegis : we return the buffer directly so that this exporter can be used the same way than the others in the calling code
 
 		};
 

--- a/metadata.txt
+++ b/metadata.txt
@@ -13,7 +13,7 @@ name=Qgis2threejs
 qgisMinimumVersion=2.0
 description=3D visualization powered by WebGL technology and three.js JavaScript library
 about=Qgis2threejs plugin exports terrain data, map canvas image and vector data to your web browser. You can view exported 3D objects on web browser which supports WebGL. This plugin makes use of three.js library.
-version=1.0
+version=1.1
 author=Minoru Akagi
 email=akaginch@gmail.com
 
@@ -23,15 +23,7 @@ email=akaginch@gmail.com
 
 # Uncomment the following line and add your changelog entries:
 changelog=
-    - layer opacity sliders in dat-gui panel
-    - wireframe mode
-    - popup style update
-    - new object types: Disk (Point), Icon (Point), Overlay (Polygon)
-    - base size option (World)
-    - option to display coordinates in WGS84 lat/lon (World)
-    - layer image option (DEM)
-    - clip geometries option (Vector)
-    - code refactoring (more oo code)
+    - updated the STLExporter to support other file formats (collada, obj) and is easier to extend (by Olivier Dalang)
 
 # tags are comma separated with spaces allowed
 tags=terrain,WebGL,3D,three.js,web


### PR DESCRIPTION
Dear Minoru,

Here's a pull request that brings some updates to the 3D file exporter template.
I made some small changes to the code to make addition of other exporters easier, and added a Collada (.dae) exporter as well as a Wavefront (.obj) exporter.

The obj exporter is very similar to the STL exporter.
The collada is a bit more complex, since the file format is much more complex. But the nice thing is that it also exports the materials (based on the color).

Please let me know what you think, and if you plan to merge it and release it to the plugin repository.

Thanks a lot for the great plugin !

Bests,

Olivier 