### PR TITLE
Update qgis2threejstools.py

### DIFF
--- a/qgis2threejstools.py
+++ b/qgis2threejstools.py
@@ -56,7 +56,7 @@ def openHTMLFile(htmlfilename):
   browserPath = settings.value("/Qgis2threejs/browser", "", type=unicode)
   if browserPath == "":
     # open default web browser
-    webbrowser.open(htmlfilename, new=2)    # new=2: new tab if possible
+    webbrowser.open("file://"+htmlfilename, new=2)    # new=2: new tab if possible
   else:
     if not QProcess.startDetached(browserPath, [QUrl.fromLocalFile(htmlfilename).toString()]):
       QMessageBox.warning(None, "Qgis2threejs", "Cannot open browser: %s\nSet correct path in settings dialog." % browserPath)


### PR DESCRIPTION
under Mac Os Yosemite, web browser won't open a local file if you don't explicitly write "file://"