### PR TITLE
[Fix] Change depecreated class

### DIFF
--- a/js/mobile.js
+++ b/js/mobile.js
@@ -261,7 +261,7 @@ function startARMode(position) {
     });
 
     var id = devices[0].deviceId;
-    navigator.getUserMedia({video: {optional: [{sourceId: id}]}}, function (stream) {
+    navigator.mediaDevices.getUserMedia({video: {optional: [{sourceId: id}]}}, function (stream) {
       var v = document.getElementById("video");
       v.addEventListener("loadedmetadata", function () {
         app.eventListener.resize();


### PR DESCRIPTION
Hi, this fix the depecreated method.
See

> The desktopCapturer API uses a legacy method, Navigator.getUserMedia() which have been removed from the Web standards and is in the process of being dropped. We're advised to not use it and instead use the newer navigator.mediaDevices.getUserMedia() method instead.

>Quote from MDN:
This is a legacy method. Please use the newer navigator.mediaDevices.getUserMedia() instead. While technically not deprecated, this old callback version is marked as such, since the specification strongly encourages using the newer promise returning version.

>Deprecated
This feature has been removed from the Web standards. Though some browsers may still support it, it is in the process of being dropped. Avoid using it and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.