### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/core/plugin/pluginmanager.py
+++ b/core/plugin/pluginmanager.py
@@ -4,6 +4,7 @@
 # begin: 2015-05-22
 
 import importlib
+import re
 import sys
 
 from qgis.PyQt.QtCore import QDir, QSettings
@@ -42,13 +43,16 @@ class PluginManager:
             plugins = p.split(",") if p else []
 
         for name in plugins:
+            name = name.strip()
+            if not name or not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', name):
+                continue
             try:
-                modname = "Qgis2threejs.plugins." + str(name)
+                modname = "Qgis2threejs.plugins." + name
                 module = importlib.reload(sys.modules[modname]) if modname in sys.modules else importlib.import_module(modname)
                 self.modules.append(module)
                 self.plugins.append(getattr(module, "plugin_class"))
             except ImportError:
-                logger.error("Failed to load plugin: " + str(name))
+                logger.error("Failed to load plugin: " + name)
 
     def demProviderPlugins(self):
         plugins = []

--- a/utils/gui.py
+++ b/utils/gui.py
@@ -2,6 +2,7 @@
 # (C) 2022 Minoru Akagi
 # SPDX-License-Identifier: GPL-2.0-or-later
 
+import os
 from qgis.PyQt.QtCore import QDir, QProcess, QSettings, QUrl
 from qgis.PyQt.QtGui import QDesktopServices
 from qgis.PyQt.QtWidgets import QFileDialog
@@ -29,7 +30,7 @@ def openUrl(url):
     if url.fileName().endswith((".html", ".htm")):
         settings = QSettings()
         browserPath = settings.value("/Qgis2threejs/browser", "", type=str)
-        if browserPath:
+        if browserPath and os.path.isfile(browserPath) and os.access(browserPath, os.X_OK):
             if QProcess.startDetached(browserPath, [url.toString()]):
                 return
             else:


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `utils/gui.py:L28`

In `utils/gui.py`, the `openUrl` function uses `QProcess.startDetached` with a user-configured browser path and a URL. While `QProcess.startDetached` with a list argument is generally safer than string concatenation, the browser path comes from user settings (`/Qgis2threejs/browser`) without validation. A malicious or malformed browser path could potentially lead to command execution if the path contains shell metacharacters or if the implementation doesn't properly handle the path. Additionally, the URL is passed as a string argument which could be manipulated.

## Solution

Validate and sanitize the browserPath before use. Use `shlex.quote()` or similar to escape the browser path. Consider using `QProcess` with explicit program and arguments rather than relying on shell parsing. Verify the browser path points to an actual executable file.

## Changes

- `utils/gui.py` (modified)
- `core/plugin/pluginmanager.py` (modified)